### PR TITLE
Update repo naming to face_mosaic_app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# mosic_ai_codex
+# face_mosaic_app
 
 アップロードした写真に人の顔があればモザイクをかける Web アプリです。
 
@@ -45,7 +45,7 @@ terraform apply
 1. AWS アカウントを作成し、[IAM ユーザー](https://docs.aws.amazon.com/ja_jp/IAM/latest/UserGuide/id_users_create.html) を用意します。アクセスキーを取得したら `aws configure` でクレデンシャルを設定します。
 2. EC2 用のキーペアを [マネジメントコンソール](https://console.aws.amazon.com/ec2/) から作成し、`terraform.tfvars` に `key_name` を設定します。キーファイル (`.pem`) は SSH 接続で必要になるので安全に保管してください。
 3. デプロイするリージョンや AMI ID を `terraform.tfvars` で指定します。Ubuntu の AMI は [AWS マーケットプレイス](https://aws.amazon.com/marketplace) などで検索できます。
-4. GitHub からアプリを取得するため `repo_url` 変数を設定します。自身のフォークを利用する場合は `https://github.com/<ユーザー名>/mosic_ai_codex` の形式で指定してください。
+4. GitHub からアプリを取得するため `repo_url` 変数を設定します。自身のフォークを利用する場合は `https://github.com/<ユーザー名>/face_mosaic_app` の形式で指定してください。
 5. 変数を用意したら次を実行します。
    ```bash
    cd terraform

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -13,7 +13,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "app" {
-  name        = "mosic-app-sg"
+  name        = "face-mosaic-app-sg"
   description = "Allow HTTP traffic"
 
   ingress {
@@ -49,14 +49,14 @@ resource "aws_instance" "app" {
               #!/bin/bash
               apt-get update
               apt-get install -y python3 python3-pip git
-              git clone ${var.repo_url} /opt/mosic_ai_codex
+              git clone ${var.repo_url} /opt/face_mosaic_app
 
-              pip3 install -r /opt/mosic_ai_codex/requirements.txt
-              PORT=${var.port} nohup python3 /opt/mosic_ai_codex/app.py &
+              pip3 install -r /opt/face_mosaic_app/requirements.txt
+              PORT=${var.port} nohup python3 /opt/face_mosaic_app/app.py &
               EOF2
 
   tags = {
-    Name = "mosic-ai-codex"
+    Name = "face-mosaic-app"
   }
 }
 

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,4 +1,4 @@
 ami_id = "ami-0ed99df77a82560e6"
-key_name = "mosic-key"         # 作成したキーペア名（.pem ではなく、名前だけ）
+key_name = "face-mosaic-key"   # 作成したキーペア名（.pem ではなく、名前だけ）
 region        = "ap-northeast-1"  # 東京リージョン
-repo_url      = "https://github.com/junya737/mosic_ai_codex"
+repo_url      = "https://github.com/junya737/face_mosaic_app"


### PR DESCRIPTION
## Summary
- rename repo references from `mosic_ai_codex` to `face_mosaic_app`
- update Terraform names and example variables

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684da2d1ac708322bd4e114a31266a72